### PR TITLE
Add ServiceContext types to lifetime scope

### DIFF
--- a/src/Autofac.Integration.ServiceFabric/StatefulServiceFactoryRegistration.cs
+++ b/src/Autofac.Integration.ServiceFabric/StatefulServiceFactoryRegistration.cs
@@ -23,6 +23,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+using System.Fabric;
 using Microsoft.ServiceFabric.Services.Runtime;
 
 namespace Autofac.Integration.ServiceFabric
@@ -35,8 +36,13 @@ namespace Autofac.Integration.ServiceFabric
         {
             ServiceRuntime.RegisterServiceAsync(serviceTypeName, context =>
             {
-                var lifetimeScope = container.BeginLifetimeScope();
-                var service = lifetimeScope.Resolve<TService>(TypedParameter.From(context));
+                var lifetimeScope = container.BeginLifetimeScope(builder =>
+                {
+                    builder.RegisterInstance(context)
+                        .As<StatefulServiceContext>()
+                        .As<ServiceContext>();
+                });
+                var service = lifetimeScope.Resolve<TService>();
                 return service;
             }).GetAwaiter().GetResult();
         }

--- a/src/Autofac.Integration.ServiceFabric/StatelessServiceFactoryRegistration.cs
+++ b/src/Autofac.Integration.ServiceFabric/StatelessServiceFactoryRegistration.cs
@@ -23,6 +23,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+using System.Fabric;
 using Microsoft.ServiceFabric.Services.Runtime;
 
 namespace Autofac.Integration.ServiceFabric
@@ -34,8 +35,13 @@ namespace Autofac.Integration.ServiceFabric
         {
             ServiceRuntime.RegisterServiceAsync(serviceTypeName, context =>
             {
-                var lifetimeScope = container.BeginLifetimeScope();
-                var service = lifetimeScope.Resolve<TService>(TypedParameter.From(context));
+                var lifetimeScope = container.BeginLifetimeScope(builder =>
+                {
+                    builder.RegisterInstance(context)
+                        .As<StatelessServiceContext>()
+                        .As<ServiceContext>();
+                });
+                var service = lifetimeScope.Resolve<TService>();
                 return service;
             }).GetAwaiter().GetResult();
         }


### PR DESCRIPTION
This change adds the `ServiceContext` types to the lifetime scope created for the service instance. This allows services to resolve the `ServiceContext` for things like logging replica ids and such.