### PR TITLE
Add 'InstancePerService' lifetime support

### DIFF
--- a/src/Autofac.Integration.ServiceFabric/ActorFactoryRegistration.cs
+++ b/src/Autofac.Integration.ServiceFabric/ActorFactoryRegistration.cs
@@ -43,15 +43,15 @@ namespace Autofac.Integration.ServiceFabric
             {
                 return new ActorService(context, actorTypeInfo, (actorService, actorId) =>
                 {
-                    var lifetimeScope = container.BeginLifetimeScope(builder =>
+                    var lifetimeScope = container.BeginLifetimeScope(RegistrationExtensions.ServiceScopeTag, builder =>
                     {
                         builder.RegisterInstance(context)
-                            .As<StatelessServiceContext>()
-                            .As<ServiceContext>();
+                               .As<StatelessServiceContext>()
+                               .As<ServiceContext>();
                         builder.RegisterInstance(actorService)
-                            .As<ActorService>();
+                               .As<ActorService>();
                         builder.RegisterInstance(actorId)
-                            .As<ActorId>();
+                               .As<ActorId>();
                     });
                     var actor = lifetimeScope.Resolve<TActor>();
                     return actor;

--- a/src/Autofac.Integration.ServiceFabric/RegistrationExtensions.cs
+++ b/src/Autofac.Integration.ServiceFabric/RegistrationExtensions.cs
@@ -24,6 +24,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using Autofac.Builder;
 using Autofac.Extras.DynamicProxy;
 using Castle.DynamicProxy;
 
@@ -60,5 +61,12 @@ namespace Autofac.Integration.ServiceFabric
                 .EnableClassInterceptors()
                 .InterceptedBy(typeof(TInterceptor));
         }
+
+        public static IRegistrationBuilder<TLimit, TActivatorData, TStyle> InstancePerService<TLimit, TActivatorData, TStyle>(this IRegistrationBuilder<TLimit, TActivatorData, TStyle> registration)
+        {
+            return registration.InstancePerMatchingLifetimeScope(ServiceScopeTag);
+        }
+
+        internal static readonly object ServiceScopeTag = new object();
     }
 }

--- a/src/Autofac.Integration.ServiceFabric/StatefulServiceFactoryRegistration.cs
+++ b/src/Autofac.Integration.ServiceFabric/StatefulServiceFactoryRegistration.cs
@@ -36,7 +36,7 @@ namespace Autofac.Integration.ServiceFabric
         {
             ServiceRuntime.RegisterServiceAsync(serviceTypeName, context =>
             {
-                var lifetimeScope = container.BeginLifetimeScope(builder =>
+                var lifetimeScope = container.BeginLifetimeScope(RegistrationExtensions.ServiceScopeTag, builder =>
                 {
                     builder.RegisterInstance(context)
                         .As<StatefulServiceContext>()

--- a/src/Autofac.Integration.ServiceFabric/StatelessServiceFactoryRegistration.cs
+++ b/src/Autofac.Integration.ServiceFabric/StatelessServiceFactoryRegistration.cs
@@ -35,7 +35,7 @@ namespace Autofac.Integration.ServiceFabric
         {
             ServiceRuntime.RegisterServiceAsync(serviceTypeName, context =>
             {
-                var lifetimeScope = container.BeginLifetimeScope(builder =>
+                var lifetimeScope = container.BeginLifetimeScope(RegistrationExtensions.ServiceScopeTag, builder =>
                 {
                     builder.RegisterInstance(context)
                         .As<StatelessServiceContext>()


### PR DESCRIPTION
This change implements an `InstancePerService` lifetime that enables one instance per service fabric service instance.