### PR TITLE
Prepare for v6 release

### DIFF
--- a/Autofac.ServiceFabric.sln
+++ b/Autofac.ServiceFabric.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30503.244
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Autofac.Integration.ServiceFabric", "src\Autofac.Integration.ServiceFabric\Autofac.Integration.ServiceFabric.csproj", "{6956F17D-A87B-4FAB-8CA8-0A6AB8A14537}"
 EndProject
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		appveyor.yml = appveyor.yml
 		build.ps1 = build.ps1
 		global.json = global.json
+		NuGet.Config = NuGet.Config
 	EndProjectSection
 EndProject
 Global

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,6 +4,7 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="Xunit MyGet" value="https://myget.org/F/xunit/api/v3/index.json" />
+    <add key="Autofac MyGet" value="https://www.myget.org/F/autofac/api/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <add key="Microsoft and .NET" value="true" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,9 @@
-version: 3.0.0.{build}
+version: 4.0.0.{build}
+
+dotnet_csproj:
+  version_prefix: '4.0.0'
+  patch: true
+  file: 'src\**\*.csproj'
 
 configuration: Release
 

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.101"
+    "version": "3.1.302",
+    "rollForward": "latestFeature"
   }
 }

--- a/src/Autofac.Integration.ServiceFabric/Autofac.Integration.ServiceFabric.csproj
+++ b/src/Autofac.Integration.ServiceFabric/Autofac.Integration.ServiceFabric.csproj
@@ -4,7 +4,7 @@
     <Description>Autofac integration for Azure Service Fabric. Provides service factory implementations for Actors, Stateful Services and Stateless Services.</Description>
     <!-- VersionPrefix patched by AppVeyor -->
     <VersionPrefix>0.0.1</VersionPrefix>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PlatformTarget>x64</PlatformTarget>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/Autofac.Integration.ServiceFabric/Autofac.Integration.ServiceFabric.csproj
+++ b/src/Autofac.Integration.ServiceFabric/Autofac.Integration.ServiceFabric.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <Description>Autofac integration for Azure Service Fabric. Provides service factory implementations for Actors, Stateful Services and Stateless Services.</Description>
-    <VersionPrefix>3.0.0</VersionPrefix>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <!-- VersionPrefix patched by AppVeyor -->
+    <VersionPrefix>0.0.1</VersionPrefix>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net472</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PlatformTarget>x64</PlatformTarget>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
@@ -15,6 +16,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <NeutralLanguage>en-US</NeutralLanguage>
     <GenerateNeutralResourcesLanguageAttribute>true</GenerateNeutralResourcesLanguageAttribute>
+    <Copyright>Copyright © 2017 Autofac Contributors</Copyright>
     <PackageId>Autofac.ServiceFabric</PackageId>
     <PackageTags>autofac;di;ioc;dependencyinjection;servicefabric;azure</PackageTags>
     <PackageReleaseNotes>Release notes are at https://github.com/autofac/Autofac.ServiceFabric/releases</PackageReleaseNotes>
@@ -38,18 +40,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="5.1.0" />
-    <PackageReference Include="Autofac.Extras.DynamicProxy" Version="5.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8">
+    <PackageReference Include="Autofac" Version="6.0.0-develop-01134" />
+    <PackageReference Include="Autofac.Extras.DynamicProxy" Version="6.0.0-develop-00280" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ServiceFabric" Version="7.0.466" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.466" />
-    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="4.0.466" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.0.466" />
+    <PackageReference Include="Microsoft.ServiceFabric" Version="7.1.458" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.1.458" />
+    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="4.1.458" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.1.458" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Autofac.Integration.ServiceFabric/Properties/AssemblyInfo.cs
+++ b/src/Autofac.Integration.ServiceFabric/Properties/AssemblyInfo.cs
@@ -1,13 +1,11 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Castle.Core.Internal;
 
 [assembly: ComVisible(false)]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-[assembly: AssemblyCopyright("Copyright © 2017 Autofac Contributors")]
+[assembly: CLSCompliant(false)]
 [assembly: InternalsVisibleTo("Autofac.Integration.ServiceFabric.Test, PublicKey=00240000048000009400000006020000002400005253413100040000010001008728425885ef385e049261b18878327dfaaf0d666dea3bd2b0e4f18b33929ad4e5fbc9087e7eda3c1291d2de579206d9b4292456abffbe8be6c7060b36da0c33b883e3878eaf7c89fddf29e6e27d24588e81e86f3a22dd7b1a296b5f06fbfb500bbd7410faa7213ef4e2ce7622aefc03169b0324bcd30ccfe9ac8204e4960be6")]
 [assembly: InternalsVisibleTo(InternalsVisible.ToDynamicProxyGenAssembly2)]
 [assembly: SuppressMessage("Microsoft.Design", "CA1020", Scope = "namespace", Target = "Autofac.Integration.ServiceFabric")]

--- a/test/Autofac.Integration.ServiceFabric.Test/Autofac.Integration.ServiceFabric.Test.csproj
+++ b/test/Autofac.Integration.ServiceFabric.Test/Autofac.Integration.ServiceFabric.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <NoWarn>$(NoWarn);CS1591;SA1602;SA1611;SA1402</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/Autofac.Integration.ServiceFabric.Test/Autofac.Integration.ServiceFabric.Test.csproj
+++ b/test/Autofac.Integration.ServiceFabric.Test/Autofac.Integration.ServiceFabric.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <NoWarn>$(NoWarn);CS1591;SA1602;SA1611;SA1402</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -19,10 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Test.Scenario.InternalsVisible/Test.Scenario.InternalsVisible.csproj
+++ b/test/Test.Scenario.InternalsVisible/Test.Scenario.InternalsVisible.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net472</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.4.0" />
-    <PackageReference Include="Microsoft.ServiceFabric" Version="7.0.466" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.466" />
-    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="4.0.466" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.0.466" />
+    <PackageReference Include="Castle.Core" Version="4.4.1" />
+    <PackageReference Include="Microsoft.ServiceFabric" Version="7.1.458" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.1.458" />
+    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="4.1.458" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.1.458" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Bump package version to `4.0.0`
- Bump `net462` target to `net472`
- Build and project standardization
- Update ServiceFabric package to latest