### PR TITLE
Convert from Moq to NSubstitute

### DIFF
--- a/test/Autofac.Integration.ServiceFabric.Test/ActorInterceptorTests.cs
+++ b/test/Autofac.Integration.ServiceFabric.Test/ActorInterceptorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Autofac Project. All rights reserved.
+﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Reflection;

--- a/test/Autofac.Integration.ServiceFabric.Test/ActorInterceptorTests.cs
+++ b/test/Autofac.Integration.ServiceFabric.Test/ActorInterceptorTests.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
+// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Reflection;
 using IInvocation = Castle.DynamicProxy.IInvocation;
 
 namespace Autofac.Integration.ServiceFabric.Test;
@@ -10,18 +11,19 @@ public sealed class ActorInterceptorTests
     [Fact]
     public void DisposesLifetimeScopeWhenTriggerMethodInvoked()
     {
-        var lifetimeScope = new Mock<ILifetimeScope>(MockBehavior.Strict);
-        lifetimeScope.Setup(x => x.Dispose()).Verifiable();
+        var lifetimeScope = Substitute.For<ILifetimeScope>();
 
-        var invocation = new Mock<IInvocation>(MockBehavior.Strict);
-        invocation.Setup(x => x.Proceed()).Verifiable();
-        invocation.Setup(x => x.Method.Name).Returns("OnDeactivateAsync").Verifiable();
+        var method = Substitute.For<MethodInfo>();
+        method.Name.Returns("OnDeactivateAsync");
 
-        var interceptor = new ActorInterceptor(lifetimeScope.Object);
+        var invocation = Substitute.For<IInvocation>();
+        invocation.Method.Returns(method);
 
-        interceptor.Intercept(invocation.Object);
+        var interceptor = new ActorInterceptor(lifetimeScope);
 
-        lifetimeScope.Verify();
-        invocation.Verify();
+        interceptor.Intercept(invocation);
+
+        lifetimeScope.Received(1).Dispose();
+        invocation.Received(1).Proceed();
     }
 }

--- a/test/Autofac.Integration.ServiceFabric.Test/Autofac.Integration.ServiceFabric.Test.csproj
+++ b/test/Autofac.Integration.ServiceFabric.Test/Autofac.Integration.ServiceFabric.Test.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Using Include="Moq" />
+    <Using Include="NSubstitute" />
     <Using Include="Xunit" />
   </ItemGroup>
 
@@ -43,7 +43,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Autofac.Integration.ServiceFabric.Test/AutofacActorExtensionsTests.cs
+++ b/test/Autofac.Integration.ServiceFabric.Test/AutofacActorExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Autofac Project. All rights reserved.
+﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Autofac.Core;

--- a/test/Autofac.Integration.ServiceFabric.Test/AutofacActorExtensionsTests.cs
+++ b/test/Autofac.Integration.ServiceFabric.Test/AutofacActorExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
+// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Autofac.Core;
@@ -16,7 +16,7 @@ public sealed class AutofacActorExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterActor<Actor1>();
-        builder.RegisterInstance(new Mock<IActorFactoryRegistration>().Object);
+        builder.RegisterInstance(Substitute.For<IActorFactoryRegistration>());
 
         var container = builder.Build();
 
@@ -28,7 +28,7 @@ public sealed class AutofacActorExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterServiceFabricSupport();
-        builder.RegisterInstance(new Mock<IActorFactoryRegistration>().Object);
+        builder.RegisterInstance(Substitute.For<IActorFactoryRegistration>());
         builder.RegisterActor<Actor1>();
 
         var container = builder.Build();
@@ -44,7 +44,7 @@ public sealed class AutofacActorExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterActor<Actor1>();
-        builder.RegisterInstance(new Mock<IActorFactoryRegistration>().Object);
+        builder.RegisterInstance(Substitute.For<IActorFactoryRegistration>());
 
         var container = builder.Build();
 
@@ -62,7 +62,7 @@ public sealed class AutofacActorExtensionsTests
         var builder = new ContainerBuilder();
         const string lifetimeScopeTag = "Tag";
         builder.RegisterActor<Actor1>(lifetimeScopeTag: lifetimeScopeTag);
-        builder.RegisterInstance(new Mock<IActorFactoryRegistration>().Object);
+        builder.RegisterInstance(Substitute.For<IActorFactoryRegistration>());
 
         var container = builder.Build();
 
@@ -79,12 +79,12 @@ public sealed class AutofacActorExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterActor<Actor1>();
-        var factoryMock = new Mock<IActorFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IActorFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var container = builder.Build();
 
-        factoryMock.Verify(x => x.RegisterActorFactory<Actor1>(container, typeof(ActorService), null, null, null, null), Times.Once);
+        factoryMock.Received(1).RegisterActorFactory<Actor1>(container, typeof(ActorService), null, null, null, null);
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public sealed class AutofacActorExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterActor<InternalsVisibleActor>();
-        builder.RegisterInstance(new Mock<IActorFactoryRegistration>().Object);
+        builder.RegisterInstance(Substitute.For<IActorFactoryRegistration>());
 
         var container = builder.Build();
 
@@ -104,13 +104,13 @@ public sealed class AutofacActorExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterModule(new ActorModule());
-        var factoryMock = new Mock<IActorFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IActorFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var container = builder.Build();
 
         container.AssertRegistered<Actor1>();
-        factoryMock.Verify(x => x.RegisterActorFactory<Actor1>(container, typeof(ActorService), null, null, null, null), Times.Once);
+        factoryMock.Received(1).RegisterActorFactory<Actor1>(container, typeof(ActorService), null, null, null, null);
     }
 
     [Fact]
@@ -121,28 +121,28 @@ public sealed class AutofacActorExtensionsTests
         // ReSharper disable once ConvertToLocalFunction
         Func<ActorBase, IActorStateProvider, IActorStateManager> stateManagerFactory = (actor, provider) => null;
         builder.RegisterActor<Actor1>(stateManagerFactory: stateManagerFactory);
-        var factoryMock = new Mock<IActorFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IActorFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var container = builder.Build();
 
         container.AssertRegistered<Actor1>();
-        factoryMock.Verify(x => x.RegisterActorFactory<Actor1>(container, typeof(ActorService), stateManagerFactory, null, null, null), Times.Once);
+        factoryMock.Received(1).RegisterActorFactory<Actor1>(container, typeof(ActorService), stateManagerFactory, null, null, null);
     }
 
     [Fact]
     public void RegisterActorCanBeCalledWithStateProvider()
     {
         var builder = new ContainerBuilder();
-        var stateProvider = new Mock<IActorStateProvider>().Object;
+        var stateProvider = Substitute.For<IActorStateProvider>();
         builder.RegisterActor<Actor1>(stateProvider: stateProvider);
-        var factoryMock = new Mock<IActorFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IActorFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var container = builder.Build();
 
         container.AssertRegistered<Actor1>();
-        factoryMock.Verify(x => x.RegisterActorFactory<Actor1>(container, typeof(ActorService), null, stateProvider, null, null), Times.Once);
+        factoryMock.Received(1).RegisterActorFactory<Actor1>(container, typeof(ActorService), null, stateProvider, null, null);
     }
 
     [Fact]
@@ -151,13 +151,13 @@ public sealed class AutofacActorExtensionsTests
         var builder = new ContainerBuilder();
         var settings = new ActorServiceSettings();
         builder.RegisterActor<Actor1>(settings: settings);
-        var factoryMock = new Mock<IActorFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IActorFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var container = builder.Build();
 
         container.AssertRegistered<Actor1>();
-        factoryMock.Verify(x => x.RegisterActorFactory<Actor1>(container, typeof(ActorService), null, null, settings, null), Times.Once);
+        factoryMock.Received(1).RegisterActorFactory<Actor1>(container, typeof(ActorService), null, null, settings, null);
     }
 
     [Fact]
@@ -166,13 +166,13 @@ public sealed class AutofacActorExtensionsTests
         var builder = new ContainerBuilder();
         const string lifetimeScopeTag = "Tag";
         builder.RegisterActor<Actor1>(lifetimeScopeTag: lifetimeScopeTag);
-        var factoryMock = new Mock<IActorFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IActorFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var container = builder.Build();
 
         container.AssertRegistered<Actor1>();
-        factoryMock.Verify(x => x.RegisterActorFactory<Actor1>(container, typeof(ActorService), null, null, null, lifetimeScopeTag), Times.Once);
+        factoryMock.Received(1).RegisterActorFactory<Actor1>(container, typeof(ActorService), null, null, null, lifetimeScopeTag);
     }
 
     [Fact]
@@ -217,8 +217,8 @@ public sealed class AutofacActorExtensionsTests
     public void ContainerBuildThrowsIfRegisterActorLifetimeScopeChangedToInstancePerDependency()
     {
         var builder = new ContainerBuilder();
-        var factoryMock = new Mock<IActorFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IActorFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
         builder.RegisterActor<Actor1>().InstancePerDependency();
 
         var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
@@ -230,8 +230,8 @@ public sealed class AutofacActorExtensionsTests
     public void ContainerBuildThrowsIfRegisterActorLifetimeScopeChangedToSingleInstance()
     {
         var builder = new ContainerBuilder();
-        var factoryMock = new Mock<IActorFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IActorFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
         builder.RegisterActor<Actor1>().SingleInstance();
 
         var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
@@ -243,8 +243,8 @@ public sealed class AutofacActorExtensionsTests
     public void ContainerBuildThrowsIfRegisterActorLifetimeScopeChangedToExternallyOwned()
     {
         var builder = new ContainerBuilder();
-        var factoryMock = new Mock<IActorFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IActorFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
         builder.RegisterActor<Actor1>().ExternallyOwned();
 
         var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());

--- a/test/Autofac.Integration.ServiceFabric.Test/AutofacServiceExtensionsTests.cs
+++ b/test/Autofac.Integration.ServiceFabric.Test/AutofacServiceExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
+// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Fabric;
@@ -17,7 +17,7 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterStatefulService<StatefulService1>("ServiceType");
-        builder.RegisterInstance(new Mock<IStatefulServiceFactoryRegistration>().Object);
+        builder.RegisterInstance(Substitute.For<IStatefulServiceFactoryRegistration>());
 
         var container = builder.Build();
 
@@ -29,7 +29,7 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterStatelessService<StatelessService1>("ServiceType");
-        builder.RegisterInstance(new Mock<IStatelessServiceFactoryRegistration>().Object);
+        builder.RegisterInstance(Substitute.For<IStatelessServiceFactoryRegistration>());
 
         var container = builder.Build();
 
@@ -42,7 +42,7 @@ public sealed class AutofacServiceExtensionsTests
         var builder = new ContainerBuilder();
         builder.RegisterStatefulService<StatefulService1>("ServiceType");
         builder.RegisterServiceFabricSupport();
-        builder.RegisterInstance(new Mock<IStatefulServiceFactoryRegistration>().Object);
+        builder.RegisterInstance(Substitute.For<IStatefulServiceFactoryRegistration>());
 
         var container = builder.Build();
 
@@ -58,7 +58,7 @@ public sealed class AutofacServiceExtensionsTests
         var builder = new ContainerBuilder();
         builder.RegisterStatelessService<StatelessService1>("ServiceType");
         builder.RegisterServiceFabricSupport();
-        builder.RegisterInstance(new Mock<IStatelessServiceFactoryRegistration>().Object);
+        builder.RegisterInstance(Substitute.For<IStatelessServiceFactoryRegistration>());
 
         var container = builder.Build();
 
@@ -73,7 +73,7 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterStatefulService<StatefulService1>("ServiceType");
-        builder.RegisterInstance(new Mock<IStatefulServiceFactoryRegistration>().Object);
+        builder.RegisterInstance(Substitute.For<IStatefulServiceFactoryRegistration>());
 
         var container = builder.Build();
 
@@ -90,7 +90,7 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterStatelessService<StatelessService1>("ServiceType");
-        builder.RegisterInstance(new Mock<IStatelessServiceFactoryRegistration>().Object);
+        builder.RegisterInstance(Substitute.For<IStatelessServiceFactoryRegistration>());
 
         var container = builder.Build();
 
@@ -108,7 +108,7 @@ public sealed class AutofacServiceExtensionsTests
         var builder = new ContainerBuilder();
         const string lifetimeScopeTag = "Tag";
         builder.RegisterStatefulService<StatefulService1>("ServiceType", lifetimeScopeTag);
-        builder.RegisterInstance(new Mock<IStatefulServiceFactoryRegistration>().Object);
+        builder.RegisterInstance(Substitute.For<IStatefulServiceFactoryRegistration>());
 
         var container = builder.Build();
 
@@ -126,7 +126,7 @@ public sealed class AutofacServiceExtensionsTests
         var builder = new ContainerBuilder();
         const string lifetimeScopeTag = "Tag";
         builder.RegisterStatelessService<StatelessService1>("ServiceType", lifetimeScopeTag);
-        builder.RegisterInstance(new Mock<IStatelessServiceFactoryRegistration>().Object);
+        builder.RegisterInstance(Substitute.For<IStatelessServiceFactoryRegistration>());
 
         var container = builder.Build();
 
@@ -143,12 +143,12 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterStatefulService<StatefulService1>("ServiceType");
-        var factoryMock = new Mock<IStatefulServiceFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IStatefulServiceFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var container = builder.Build();
 
-        factoryMock.Verify(x => x.RegisterStatefulServiceFactory<StatefulService1>(container, "ServiceType", null), Times.Once);
+        factoryMock.Received(1).RegisterStatefulServiceFactory<StatefulService1>(container, "ServiceType", null);
     }
 
     [Fact]
@@ -156,12 +156,12 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterStatelessService<StatelessService1>("ServiceType");
-        var factoryMock = new Mock<IStatelessServiceFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IStatelessServiceFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var container = builder.Build();
 
-        factoryMock.Verify(x => x.RegisterStatelessServiceFactory<StatelessService1>(container, "ServiceType", null), Times.Once);
+        factoryMock.Received(1).RegisterStatelessServiceFactory<StatelessService1>(container, "ServiceType", null);
     }
 
     [Fact]
@@ -170,13 +170,13 @@ public sealed class AutofacServiceExtensionsTests
         var builder = new ContainerBuilder();
         const string lifetimeScopeTag = "CustomTag";
         builder.RegisterStatefulService<StatefulService1>("ServiceType", lifetimeScopeTag);
-        var factoryMock = new Mock<IStatefulServiceFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IStatefulServiceFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var container = builder.Build();
 
         container.AssertRegistered<StatefulService1>();
-        factoryMock.Verify(x => x.RegisterStatefulServiceFactory<StatefulService1>(container, "ServiceType", lifetimeScopeTag), Times.Once);
+        factoryMock.Received(1).RegisterStatefulServiceFactory<StatefulService1>(container, "ServiceType", lifetimeScopeTag);
     }
 
     [Fact]
@@ -185,13 +185,13 @@ public sealed class AutofacServiceExtensionsTests
         var builder = new ContainerBuilder();
         const string lifetimeScopeTag = "CustomTag";
         builder.RegisterStatelessService<StatelessService1>("ServiceType", lifetimeScopeTag);
-        var factoryMock = new Mock<IStatelessServiceFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IStatelessServiceFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var container = builder.Build();
 
         container.AssertRegistered<StatelessService1>();
-        factoryMock.Verify(x => x.RegisterStatelessServiceFactory<StatelessService1>(container, "ServiceType", lifetimeScopeTag), Times.Once);
+        factoryMock.Received(1).RegisterStatelessServiceFactory<StatelessService1>(container, "ServiceType", lifetimeScopeTag);
     }
 
     [Fact]
@@ -199,7 +199,7 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterStatefulService<InternalsVisibleStatefulService>("ServiceType");
-        builder.RegisterInstance(new Mock<IStatefulServiceFactoryRegistration>().Object);
+        builder.RegisterInstance(Substitute.For<IStatefulServiceFactoryRegistration>());
 
         var container = builder.Build();
 
@@ -211,7 +211,7 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterStatelessService<InternalsVisibleStatelessService>("ServiceType");
-        builder.RegisterInstance(new Mock<IStatelessServiceFactoryRegistration>().Object);
+        builder.RegisterInstance(Substitute.For<IStatelessServiceFactoryRegistration>());
 
         var container = builder.Build();
 
@@ -223,13 +223,13 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterModule(new StatefulServiceModule());
-        var factoryMock = new Mock<IStatefulServiceFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IStatefulServiceFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var container = builder.Build();
 
         container.AssertRegistered<StatefulService1>();
-        factoryMock.Verify(x => x.RegisterStatefulServiceFactory<StatefulService1>(container, "serviceTypeName", null), Times.Once);
+        factoryMock.Received(1).RegisterStatefulServiceFactory<StatefulService1>(container, "serviceTypeName", null);
     }
 
     [Fact]
@@ -237,13 +237,13 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterModule(new StatelessServiceModule());
-        var factoryMock = new Mock<IStatelessServiceFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IStatelessServiceFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var container = builder.Build();
 
         container.AssertRegistered<StatelessService1>();
-        factoryMock.Verify(x => x.RegisterStatelessServiceFactory<StatelessService1>(container, "serviceTypeName", null), Times.Once);
+        factoryMock.Received(1).RegisterStatelessServiceFactory<StatelessService1>(container, "serviceTypeName", null);
     }
 
     [Fact]
@@ -357,8 +357,8 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterStatefulService<StatefulService1>("serviceTypeName").InstancePerDependency();
-        var factoryMock = new Mock<IStatefulServiceFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IStatefulServiceFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
 
@@ -370,8 +370,8 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterStatelessService<StatelessService1>("serviceTypeName").InstancePerDependency();
-        var factoryMock = new Mock<IStatelessServiceFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IStatelessServiceFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
 
@@ -383,8 +383,8 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterStatefulService<StatefulService1>("serviceTypeName").SingleInstance();
-        var factoryMock = new Mock<IStatefulServiceFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IStatefulServiceFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
 
@@ -396,8 +396,8 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterStatelessService<StatelessService1>("serviceTypeName").SingleInstance();
-        var factoryMock = new Mock<IStatelessServiceFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IStatelessServiceFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
 
@@ -409,8 +409,8 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterStatefulService<StatefulService1>("serviceTypeName").ExternallyOwned();
-        var factoryMock = new Mock<IStatefulServiceFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IStatefulServiceFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
 
@@ -422,8 +422,8 @@ public sealed class AutofacServiceExtensionsTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterStatelessService<StatelessService1>("serviceTypeName").ExternallyOwned();
-        var factoryMock = new Mock<IStatelessServiceFactoryRegistration>();
-        builder.RegisterInstance(factoryMock.Object);
+        var factoryMock = Substitute.For<IStatelessServiceFactoryRegistration>();
+        builder.RegisterInstance(factoryMock);
 
         var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
 

--- a/test/Autofac.Integration.ServiceFabric.Test/AutofacServiceExtensionsTests.cs
+++ b/test/Autofac.Integration.ServiceFabric.Test/AutofacServiceExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Autofac Project. All rights reserved.
+﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Fabric;

--- a/test/Autofac.Integration.ServiceFabric.Test/ServiceInterceptorTests.cs
+++ b/test/Autofac.Integration.ServiceFabric.Test/ServiceInterceptorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Autofac Project. All rights reserved.
+﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Reflection;

--- a/test/Autofac.Integration.ServiceFabric.Test/ServiceInterceptorTests.cs
+++ b/test/Autofac.Integration.ServiceFabric.Test/ServiceInterceptorTests.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
+// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Reflection;
 using IInvocation = Castle.DynamicProxy.IInvocation;
 
 namespace Autofac.Integration.ServiceFabric.Test;
@@ -12,18 +13,19 @@ public sealed class ServiceInterceptorTests
     [InlineData("OnAbort")]
     public void DisposesLifetimeScopeWhenTriggerMethodInvoked(string methodName)
     {
-        var lifetimeScope = new Mock<ILifetimeScope>(MockBehavior.Strict);
-        lifetimeScope.Setup(x => x.Dispose()).Verifiable();
+        var lifetimeScope = Substitute.For<ILifetimeScope>();
 
-        var invocation = new Mock<IInvocation>(MockBehavior.Strict);
-        invocation.Setup(x => x.Proceed()).Verifiable();
-        invocation.Setup(x => x.Method.Name).Returns(methodName).Verifiable();
+        var method = Substitute.For<MethodInfo>();
+        method.Name.Returns(methodName);
 
-        var interceptor = new ServiceInterceptor(lifetimeScope.Object);
+        var invocation = Substitute.For<IInvocation>();
+        invocation.Method.Returns(method);
 
-        interceptor.Intercept(invocation.Object);
+        var interceptor = new ServiceInterceptor(lifetimeScope);
 
-        lifetimeScope.Verify();
-        invocation.Verify();
+        interceptor.Intercept(invocation);
+
+        lifetimeScope.Received(1).Dispose();
+        invocation.Received(1).Proceed();
     }
 }


### PR DESCRIPTION
## Summary
- Replace Moq with NSubstitute 5.3.0
- Convert 4 test files including MockBehavior.Strict patterns and extensive Setup/Verify
- Part of cross-repo effort to standardize on NSubstitute

## Test plan
- [x] Build succeeds locally (net10.0)
- [ ] CI tests pass (requires x64 platform target, not available locally)