### PR TITLE
Standardize build metadata and code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,5 @@
-; EditorConfig to support per-solution formatting.
-; Use the EditorConfig VS add-in to make this work.
-; http://editorconfig.org/
-
-; This is the default for the codeline.
+# EditorConfig to support per-solution formatting.
+# http://editorconfig.org/
 root = true
 
 [*]
@@ -10,13 +7,187 @@ indent_style = space
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-; .NET Code - almost, but not exactly, the same suggestions as corefx
-; https://github.com/dotnet/corefx/blob/master/.editorconfig
+# .NET Code
 [*.cs]
 indent_size = 4
 charset = utf-8-bom
 
-; New line preferences
+# .NET project files and MSBuild - match defaults for VS
+[*.{csproj,nuspec,proj,projitems,props,shproj,targets,vbproj,vcxproj,vcxproj.filters,vsixmanifest,vsct}]
+indent_size = 2
+
+# .NET solution files - match defaults for VS
+[*.sln]
+end_of_line = crlf
+indent_style = tab
+
+# .NET XML solution files - match dotnet new sln defaults
+[*.slnx]
+indent_size = 2
+
+
+# Config - match XML and default nuget.config template
+[*.config]
+indent_size = 2
+
+# Resources - match defaults for VS
+[*.resx]
+indent_size = 2
+
+# Static analysis rulesets - match defaults for VS
+[*.ruleset]
+indent_size = 2
+
+# HTML, XML - match defaults for VS
+[*.{cshtml,html,xml}]
+indent_size = 4
+
+# JavaScript and JS mixes - match eslint settings; JSON also matches .NET Core templates
+[*.{js,json,mjs,ts,vue}]
+indent_size = 2
+
+# Markdown - match markdownlint settings
+[*.{md,markdown}]
+indent_size = 2
+
+# PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
+[*.{ps1,psd1,psm1}]
+indent_size = 4
+charset = utf-8-bom
+
+# YAML - match standard YAML like Kubernetes and GitHub Actions
+[*.{yaml,yml}]
+indent_size = 2
+
+# ReStructuredText - standard indentation format from examples
+[*.rst]
+indent_size = 2
+
+#
+# dotnet code style
+#
+[*.cs]
+
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# Avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+
+# Whitespace options
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Non-private static fields are PascalCase
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols = non_private_static_fields
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
+
+dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
+
+dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
+
+# Non-private readonly fields are PascalCase
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_readonly_field_style
+
+dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
+
+dotnet_naming_style.non_private_readonly_field_style.capitalization = pascal_case
+
+# Constants are PascalCase
+dotnet_naming_rule.constants_should_be_pascal_case.severity = warning
+dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
+dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
+
+dotnet_naming_symbols.constants.applicable_kinds = field, local
+dotnet_naming_symbols.constants.required_modifiers = const
+
+dotnet_naming_style.constant_style.capitalization = pascal_case
+
+# Static fields should be _camelCase
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
+dotnet_naming_style.static_field_style.capitalization = camel_case
+
+# Instance fields are camelCase and start with _
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+
+dotnet_naming_symbols.instance_fields.applicable_kinds = field
+
+dotnet_naming_style.instance_field_style.capitalization = camel_case
+dotnet_naming_style.instance_field_style.required_prefix = _
+
+# Locals and parameters are camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity = warning
+dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
+dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
+
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
+
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# Local functions are PascalCase
+dotnet_naming_rule.local_functions_should_be_pascal_case.severity = warning
+dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
+dotnet_naming_rule.local_functions_should_be_pascal_case.style = local_function_style
+
+dotnet_naming_symbols.local_functions.applicable_kinds = local_function
+
+dotnet_naming_style.local_function_style.capitalization = pascal_case
+
+# By default, name items with PascalCase
+dotnet_naming_rule.members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
+dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
+
+dotnet_naming_symbols.all_members.applicable_kinds = *
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# IDE0035: Remove unreachable code
+dotnet_diagnostic.IDE0035.severity = warning
+
+# IDE0036: Order modifiers
+dotnet_diagnostic.IDE0036.severity = warning
+
+# IDE0043: Format string contains invalid placeholder
+dotnet_diagnostic.IDE0043.severity = warning
+
+# IDE0044: Make field readonly
+dotnet_diagnostic.IDE0044.severity = warning
+
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = warning
+
+# C# code style
+#
+# Newline settings
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
@@ -25,90 +196,34 @@ csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
-; Indentation preferences
+# Indentation preferences
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_case_contents_when_block = true
 csharp_indent_switch_labels = true
-csharp_indent_labels = one_less_than_current
+csharp_indent_labels = flush_left
 
-; Modifier preferences
-csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:warning
+# Whitespace options
+# Each of the *_experimental rules has a corresponding IDE* setting.
+csharp_style_allow_embedded_statements_on_same_line_experimental = false
+dotnet_diagnostic.IDE2001.severity = warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+dotnet_diagnostic.IDE2002.severity = warning
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
+dotnet_diagnostic.IDE2004.severity = warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = false
+dotnet_diagnostic.IDE2005.severity = warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false
+dotnet_diagnostic.IDE2006.severity = warning
 
-; Avoid this. unless absolutely necessary
-dotnet_style_qualification_for_field = false:suggestion
-dotnet_style_qualification_for_property = false:suggestion
-dotnet_style_qualification_for_method = false:suggestion
-dotnet_style_qualification_for_event = false:suggestion
+# Prefer "var" everywhere
+dotnet_diagnostic.IDE0007.severity = warning
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
 
-; Types: use keywords instead of BCL types, using var is fine.
-csharp_style_var_when_type_is_apparent = false:none
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = true:suggestion
-
-; Name all constant fields using PascalCase
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.constant_fields.applicable_kinds   = field
-dotnet_naming_symbols.constant_fields.required_modifiers = const
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
-
-; Static fields should be _camelCase
-dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
-dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
-dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
-dotnet_naming_symbols.static_fields.applicable_kinds   = field
-dotnet_naming_symbols.static_fields.required_modifiers = static
-dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
-
-; Static readonly fields should be PascalCase
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.severity = warning
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.symbols  = static_readonly_fields
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.static_readonly_fields.applicable_kinds   = field
-dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readonly
-dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = private, internal, private_protected
-
-; Internal and private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_internal_fields.severity = warning
-dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
-dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
-dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
-dotnet_naming_style.camel_case_underscore_style.required_prefix = _
-dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
-
-; Code style defaults
-csharp_using_directive_placement = outside_namespace:suggestion
-dotnet_sort_system_directives_first = true
-csharp_prefer_braces = true:refactoring
-csharp_preserve_single_line_blocks = true:none
-csharp_preserve_single_line_statements = false:none
-csharp_prefer_static_local_function = true:suggestion
-csharp_prefer_simple_using_statement = false:none
-csharp_style_prefer_switch_expression = true:suggestion
-
-; Code quality
-dotnet_style_readonly_field = true:suggestion
-dotnet_code_quality_unused_parameters = non_public:suggestion
-
-; Expression-level preferences
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring
-dotnet_style_prefer_conditional_expression_over_return = true:refactoring
-csharp_prefer_simple_default_expression = true:suggestion
-
-# Expression-bodied members
+# Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = true:refactoring
 csharp_style_expression_bodied_constructors = true:refactoring
 csharp_style_expression_bodied_operators = true:refactoring
@@ -118,20 +233,15 @@ csharp_style_expression_bodied_accessors = true:refactoring
 csharp_style_expression_bodied_lambdas = true:refactoring
 csharp_style_expression_bodied_local_functions = true:refactoring
 
-# Pattern matching
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-
-# Null checking preferences
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
-
-# Other features
-csharp_style_namespace_declarations = file_scoped:suggestion
-csharp_style_prefer_index_operator = false:none
-csharp_style_prefer_range_operator = false:none
-csharp_style_pattern_local_over_anonymous_function = false:none
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_inlined_variable_declaration = true:warning
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+csharp_style_prefer_extended_property_pattern = true:warning
+csharp_style_namespace_declarations = file_scoped:warning
+csharp_style_prefer_parameter_null_checking = false
 
 # Space preferences
 csharp_space_after_cast = false
@@ -157,48 +267,30 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
-; .NET project files and MSBuild - match defaults for VS
-[*.{csproj,nuspec,proj,projitems,props,shproj,targets,vbproj,vcxproj,vcxproj.filters,vsixmanifest,vsct}]
-indent_size = 2
+# Blocks required
+csharp_prefer_braces = true:warning
+csharp_preserve_single_line_blocks = false
+csharp_preserve_single_line_statements = false
 
-; .NET solution files - match defaults for VS
-[*.sln]
-end_of_line = crlf
-indent_style = tab
+# IDE0011: Add braces
+csharp_prefer_braces = when_multiline:warning
+# NOTE: We need the below severity entry for Add Braces due to https://github.com/dotnet/roslyn/issues/44201
+dotnet_diagnostic.IDE0011.severity = warning
 
-; Config - match XML and default nuget.config template
-[*.config]
-indent_size = 2
+# IDE0040: Add accessibility modifiers
+dotnet_diagnostic.IDE0040.severity = warning
 
-; Resources - match defaults for VS
-[*.resx]
-indent_size = 2
+# IDE0052: Remove unread private member
+dotnet_diagnostic.IDE0052.severity = warning
 
-; Static analysis rulesets - match defaults for VS
-[*.ruleset]
-indent_size = 2
+# IDE0059: Unnecessary assignment to a value
+dotnet_diagnostic.IDE0059.severity = warning
 
-; HTML, XML - match defaults for VS
-[*.{cshtml,html,xml}]
-indent_size = 4
+# IDE0060: Remove unused parameter
+dotnet_diagnostic.IDE0060.severity = warning
 
-; JavaScript and JS mixes - match eslint settings; JSON also matches .NET Core templates
-[*.{js,json,ts,vue}]
-indent_size = 2
+# CA1012: Abstract types should not have public constructors
+dotnet_diagnostic.CA1012.severity = warning
 
-; Markdown - match markdownlint settings
-[*.{md,markdown}]
-indent_size = 2
-
-; PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
-[*.{ps1,psd1,psm1}]
-indent_size = 4
-charset = utf-8-bom
-
-; ReStructuredText - standard indentation format from examples
-[*.rst]
-indent_size = 2
-
-# YAML - match standard YAML like Kubernetes and GitHub Actions
-[*.{yaml,yml}]
-indent_size = 2
+# CA1822: Make member static
+dotnet_diagnostic.CA1822.severity = warning

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
+    rev: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"  # frozen: v6.0.0
     hooks:
       - id: check-json
       - id: check-yaml
@@ -8,13 +8,13 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: e72a3ca1632f0b11a07d171449fe447a7ff6795e  # frozen: v0.48.0
+    rev: "e72a3ca1632f0b11a07d171449fe447a7ff6795e"  # frozen: v0.48.0
     hooks:
       - id: markdownlint
         args:
           - --fix
   - repo: https://github.com/tillig/json-sort-cli
-    rev: 2b7e147e0933bd30b58133b6f287e5c695ff4f0e  # frozen: v3.0.1
+    rev: "2b7e147e0933bd30b58133b6f287e5c695ff4f0e"  # frozen: v3.0.1
     hooks:
       - id: json-sort
         args:

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -4,47 +4,39 @@
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
     <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Avoid excessive inheritance (must be explicitly enabled). -->
+    <Rule Id="CA1501" Action="Warning" />
+    <!-- Avoid excessive complexity (must be explicitly enabled). -->
+    <Rule Id="CA1502" Action="Warning" />
+    <!-- Avoid unmaintainable code (must be explicitly enabled). -->
+    <Rule Id="CA1505" Action="Warning" />
+    <!-- Avoid excessive class coupling (must be explicitly enabled). -->
+    <Rule Id="CA1506" Action="Warning" />
+    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <Rule Id="CA1510" Action="None" />
+    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - this isn't available until we stop targeting anything below net8.0. -->
+    <Rule Id="CA1512" Action="None" />
+    <!-- Use ObjectDisposedException.ThrowIf - this isn't available until we stop targeting anything below net8.0. -->
+    <Rule Id="CA1513" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core -->
+    <!-- Cache a CompositeFormat object for use in String.Format - this isn't available until we stop targeting netstandard, and we only String.Format when throwing exceptions so the work/complexity isn't justified to increase perf just for those situations. -->
+    <Rule Id="CA1863" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads to using Type parameters - many aren't available in earlier frameworks; and we do a lot of reflection work in Autofac. -->
+    <Rule Id="CA2263" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <!-- Prefix local calls with this -->
+    <!-- Prefix local calls with this. -->
     <Rule Id="SA1101" Action="None" />
-    <!-- Use built-in type alias -->
+    <!-- Use built-in type alias. -->
     <Rule Id="SA1121" Action="None" />
-    <!-- Use String.Empty instead of "" -->
+    <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Using statements must be inside a namespace -->
-    <Rule Id="SA1200" Action="None" />
-    <!-- Enforce order of class members by member type -->
-    <Rule Id="SA1201" Action="None" />
-    <!-- Enforce order of class members by member visibility -->
-    <Rule Id="SA1202" Action="None" />
-    <!-- Enforce order of constantand static members -->
-    <Rule Id="SA1203" Action="None" />
-    <!-- Enforce order of static vs. non-static members -->
-    <Rule Id="SA1204" Action="None" />
-    <!-- Enforce order of readonly vs. non-readonly members -->
-    <Rule Id="SA1214" Action="None" />
-    <!-- Fields can't start with underscore -->
+    <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
-    <!-- Suppressions must have a justification -->
-    <Rule Id="SA1404" Action="None" />
-    <!-- Parameter documentation must be in the right order -->
-    <Rule Id="SA1612" Action="None" />
-    <!-- Return value must be documented -->
-    <Rule Id="SA1615" Action="None" />
-    <!-- Generic type parameters must be documented -->
-    <Rule Id="SA1618" Action="None" />
-    <!-- Don't copy/paste documentation -->
-    <Rule Id="SA1625" Action="None" />
-    <!-- Exception documentation must not be empty -->
-    <Rule Id="SA1627" Action="None" />
-    <!-- Enable XML documentation output-->
-    <Rule Id="SA1652" Action="None" />
   </Rules>
 </RuleSet>

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -1,51 +1,92 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac test assemblies." ToolsVersion="16.0">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
+    <!-- Avoid excessive parameters on generic types (must be explicitly enabled). -->
     <Rule Id="CA1005" Action="Warning" />
+    <!-- Don't catch general exceptions - test scenarios sometimes require general exception handling. -->
     <Rule Id="CA1031" Action="None" />
+    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Avoid empty interfaces - in unit tests for service resolution, this happens a lot. -->
     <Rule Id="CA1040" Action="None" />
+    <!-- Do not pass literals as localized parameters  - tests don't need to localize. -->
     <Rule Id="CA1303" Action="None" />
+    <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
+    <!-- Avoid excessive complexity (must be explicitly enabled). -->
     <Rule Id="CA1502" Action="Warning" />
+    <!-- Avoid unmaintainable code (must be explicitly enabled). -->
     <Rule Id="CA1505" Action="Warning" />
+    <!-- Avoid excessive class coupling (must be explicitly enabled). -->
     <Rule Id="CA1506" Action="Warning" />
+    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
     <Rule Id="CA1510" Action="None" />
+    <!-- Make API types internal - causes problems with tests and test assemblies. -->
     <Rule Id="CA1515" Action="None" />
+    <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
     <Rule Id="CA1707" Action="None" />
+    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
+    <!-- Internal class that appears to never be instantiated - lots of false positives here because they're test stubs created by Autofac registrations. -->
     <Rule Id="CA1812" Action="None" />
+    <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
     <Rule Id="CA1816" Action="None" />
+    <!-- Mark members static - test methods may not access member data but also can't be static. -->
     <Rule Id="CA1822" Action="None" />
+    <!-- Seal internal types for performance - in tests we don't really care and it gets painful to enforce. -->
     <Rule Id="CA1852" Action="None" />
+    <!-- Prefer static readonly fields over constant array arguments - constant array arguments happen a lot in unit tests for assertions and test setup. -->
     <Rule Id="CA1861" Action="None" />
+    <!-- Cache a CompositeFormat object for use in String.Format - this makes unit tests harder to read, and performance isn't an issue. -->
     <Rule Id="CA1863" Action="None" />
+    <!-- Call ConfigureAwait on tasks - you shouldn't do this in unit test libraries; XUnit has an opposite analyzer. -->
     <Rule Id="CA2007" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
     <Rule Id="CA2229" Action="None" />
+    <!-- Use Uri instead of string parameters - strings are easier for testing. -->
     <Rule Id="CA2234" Action="None" />
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads to using Type parameters - we do a lot of reflection work in Autofac that needs to be tested. -->
     <Rule Id="CA2263" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <!-- Prefix local calls with this. -->
     <Rule Id="SA1101" Action="None" />
+    <!-- Use built-in type alias. -->
     <Rule Id="SA1121" Action="None" />
+    <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
+    <!-- Enforce order of class members by member type - sometimes putting test classes/data by the test helps. -->
     <Rule Id="SA1201" Action="None" />
+    <!-- Enforce order of class members by member visibility - sometimes putting test classes/data by the test helps. -->
     <Rule Id="SA1202" Action="None" />
+    <!-- Enforce order of static vs. non-static members - sometimes putting test classes/data by the test helps. -->
     <Rule Id="SA1204" Action="None" />
+    <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
+    <!-- Elements should be documented. -->
     <Rule Id="SA1600" Action="None" />
+    <!-- Partial items should be documented. -->
     <Rule Id="SA1601" Action="None" />
+    <!-- Enumeration items should be documented. -->
     <Rule Id="SA1602" Action="None" />
+    <!-- Parameter should be documented. -->
     <Rule Id="SA1611" Action="None" />
+    <!-- Parameter documentation must be in the right order. -->
     <Rule Id="SA1612" Action="None" />
+    <!-- Return value must be documented. -->
     <Rule Id="SA1615" Action="None" />
+    <!-- Generic type parameters must be documented. -->
     <Rule Id="SA1618" Action="None" />
+    <!-- Don't copy/paste documentation. -->
     <Rule Id="SA1625" Action="None" />
-    <Rule Id="SA1633" Action="None" />
+    <!-- Private member is unused - tests for reflection require members that may not get used. -->
     <Rule Id="IDE0051" Action="None" />
+    <!-- Private member assigned value never read - tests for reflection require values that may not get used. -->
     <Rule Id="IDE0052" Action="None" />
+    <!-- Remove unused parameter - tests for reflection require parameters that may not get used. -->
     <Rule Id="IDE0060" Action="None" />
   </Rules>
 </RuleSet>

--- a/build/stylecop.json
+++ b/build/stylecop.json
@@ -9,6 +9,9 @@
         "licenseName": "MIT"
       },
       "xmlHeader": false
+    },
+    "orderingRules": {
+      "usingDirectivesPlacement": "outsideNamespace"
     }
   }
 }

--- a/default.proj
+++ b/default.proj
@@ -56,7 +56,8 @@
     <Exec Command="dotnet build &quot;%(SolutionFile.FullPath)&quot; -c $(Configuration) /p:Version=$(Version)" />
   </Target>
   <Target Name="Package">
-    <Exec Command="dotnet pack &quot;%(SolutionFile.FullPath)&quot; -c $(Configuration) --output &quot;$(PackageDirectory)&quot; /p:Version=$(Version)" />
+    <MakeDir Directories="$(PackageDirectory)" />
+    <Exec Command="dotnet pack &quot;%(SourceProject.Identity)&quot; -c $(Configuration) --no-build --output &quot;$(PackageDirectory)&quot; /p:Version=$(Version)" />
   </Target>
   <Target Name="Test">
     <MakeDir Directories="$(LogDirectory)" />

--- a/src/Autofac.Integration.ServiceFabric/ActorFactoryRegistration.cs
+++ b/src/Autofac.Integration.ServiceFabric/ActorFactoryRegistration.cs
@@ -15,16 +15,6 @@ namespace Autofac.Integration.ServiceFabric;
 internal sealed class ActorFactoryRegistration : IActorFactoryRegistration
 {
     /// <summary>
-    /// Gets a callback that will be invoked if an exception is thrown during resolving.
-    /// </summary>
-    internal Action<Exception> ConstructorExceptionCallback { get; }
-
-    /// <summary>
-    /// Gets a callback that will be invoked while configuring the lifetime scope for a service.
-    /// </summary>
-    internal Action<ContainerBuilder> ConfigurationAction { get; }
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="ActorFactoryRegistration"/> class.
     /// </summary>
     /// <param name="constructorExceptionCallback">Callback will be invoked if an exception is thrown during resolving.</param>
@@ -36,6 +26,22 @@ internal sealed class ActorFactoryRegistration : IActorFactoryRegistration
     {
         ConstructorExceptionCallback = constructorExceptionCallback;
         ConfigurationAction = configurationAction;
+    }
+
+    /// <summary>
+    /// Gets a callback that will be invoked if an exception is thrown during resolving.
+    /// </summary>
+    internal Action<Exception> ConstructorExceptionCallback
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets a callback that will be invoked while configuring the lifetime scope for a service.
+    /// </summary>
+    internal Action<ContainerBuilder> ConfigurationAction
+    {
+        get;
     }
 
     /// <inheritdoc />

--- a/src/Autofac.Integration.ServiceFabric/Properties/AssemblyInfo.cs
+++ b/src/Autofac.Integration.ServiceFabric/Properties/AssemblyInfo.cs
@@ -9,4 +9,4 @@ using Castle.Core.Internal;
 [assembly: CLSCompliant(false)]
 [assembly: InternalsVisibleTo("Autofac.Integration.ServiceFabric.Test, PublicKey=00240000048000009400000006020000002400005253413100040000010001008728425885ef385e049261b18878327dfaaf0d666dea3bd2b0e4f18b33929ad4e5fbc9087e7eda3c1291d2de579206d9b4292456abffbe8be6c7060b36da0c33b883e3878eaf7c89fddf29e6e27d24588e81e86f3a22dd7b1a296b5f06fbfb500bbd7410faa7213ef4e2ce7622aefc03169b0324bcd30ccfe9ac8204e4960be6")]
 [assembly: InternalsVisibleTo(InternalsVisible.ToDynamicProxyGenAssembly2)]
-[assembly: SuppressMessage("Microsoft.Design", "CA1020", Scope = "namespace", Target = "Autofac.Integration.ServiceFabric")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1020", Scope = "namespace", Target = "Autofac.Integration.ServiceFabric", Justification = "Single namespace for integration package.")]

--- a/src/Autofac.Integration.ServiceFabric/StatefulServiceFactoryRegistration.cs
+++ b/src/Autofac.Integration.ServiceFabric/StatefulServiceFactoryRegistration.cs
@@ -14,16 +14,6 @@ namespace Autofac.Integration.ServiceFabric;
 internal sealed class StatefulServiceFactoryRegistration : IStatefulServiceFactoryRegistration
 {
     /// <summary>
-    /// Gets a callback that will be invoked if an exception is thrown during resolving.
-    /// </summary>
-    internal Action<Exception> ConstructorExceptionCallback { get; }
-
-    /// <summary>
-    /// Gets a callback that will be invoked while configuring the lifetime scope for a service.
-    /// </summary>
-    internal Action<ContainerBuilder> ConfigurationAction { get; }
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="StatefulServiceFactoryRegistration"/> class.
     /// </summary>
     /// <param name="constructorExceptionCallback">Callback will be invoked if an exception is thrown during resolving.</param>
@@ -35,6 +25,22 @@ internal sealed class StatefulServiceFactoryRegistration : IStatefulServiceFacto
     {
         ConstructorExceptionCallback = constructorExceptionCallback;
         ConfigurationAction = configurationAction;
+    }
+
+    /// <summary>
+    /// Gets a callback that will be invoked if an exception is thrown during resolving.
+    /// </summary>
+    internal Action<Exception> ConstructorExceptionCallback
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets a callback that will be invoked while configuring the lifetime scope for a service.
+    /// </summary>
+    internal Action<ContainerBuilder> ConfigurationAction
+    {
+        get;
     }
 
     /// <inheritdoc />

--- a/src/Autofac.Integration.ServiceFabric/StatelessServiceFactoryRegistration.cs
+++ b/src/Autofac.Integration.ServiceFabric/StatelessServiceFactoryRegistration.cs
@@ -14,16 +14,6 @@ namespace Autofac.Integration.ServiceFabric;
 internal sealed class StatelessServiceFactoryRegistration : IStatelessServiceFactoryRegistration
 {
     /// <summary>
-    /// Gets a callback that will be invoked if an exception is thrown during resolving.
-    /// </summary>
-    internal Action<Exception> ConstructorExceptionCallback { get; }
-
-    /// <summary>
-    /// Gets a callback that will be invoked while configuring the lifetime scope for a service.
-    /// </summary>
-    internal Action<ContainerBuilder> ConfigurationAction { get; }
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="StatelessServiceFactoryRegistration"/> class.
     /// </summary>
     /// <param name="constructorExceptionCallback">Callback will be invoked if an exception is thrown during resolving.</param>
@@ -35,6 +25,22 @@ internal sealed class StatelessServiceFactoryRegistration : IStatelessServiceFac
     {
         ConstructorExceptionCallback = constructorExceptionCallback;
         ConfigurationAction = configurationAction;
+    }
+
+    /// <summary>
+    /// Gets a callback that will be invoked if an exception is thrown during resolving.
+    /// </summary>
+    internal Action<Exception> ConstructorExceptionCallback
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets a callback that will be invoked while configuring the lifetime scope for a service.
+    /// </summary>
+    internal Action<ContainerBuilder> ConfigurationAction
+    {
+        get;
     }
 
     /// <inheritdoc />

--- a/test/Autofac.Integration.ServiceFabric.Test/AutofacActorExtensionsTests.cs
+++ b/test/Autofac.Integration.ServiceFabric.Test/AutofacActorExtensionsTests.cs
@@ -34,8 +34,8 @@ public sealed class AutofacActorExtensionsTests
         var container = builder.Build();
 
         var registration = container.RegistrationFor<Actor1>();
-        const string metadataKey = "Autofac.Extras.DynamicProxy.RegistrationExtensions.InterceptorsPropertyName";
-        var interceptorServices = (IEnumerable<Service>)registration.Metadata[metadataKey];
+        const string MetadataKey = "Autofac.Extras.DynamicProxy.RegistrationExtensions.InterceptorsPropertyName";
+        var interceptorServices = (IEnumerable<Service>)registration.Metadata[MetadataKey];
         Assert.Contains(new TypedService(typeof(ActorInterceptor)), interceptorServices);
     }
 
@@ -60,8 +60,8 @@ public sealed class AutofacActorExtensionsTests
     public void RegisterActorWithTagRegistersInstancePerMatchingLifetimeScope()
     {
         var builder = new ContainerBuilder();
-        const string lifetimeScopeTag = "Tag";
-        builder.RegisterActor<Actor1>(lifetimeScopeTag: lifetimeScopeTag);
+        const string LifetimeScopeTag = "Tag";
+        builder.RegisterActor<Actor1>(lifetimeScopeTag: LifetimeScopeTag);
         builder.RegisterInstance(Substitute.For<IActorFactoryRegistration>());
 
         var container = builder.Build();
@@ -71,7 +71,7 @@ public sealed class AutofacActorExtensionsTests
         container.AssertOwnership<Actor1>(InstanceOwnership.OwnedByLifetimeScope);
 
         var lifetime = (MatchingScopeLifetime)container.RegistrationFor<Actor1>().Lifetime;
-        Assert.Contains(lifetimeScopeTag, lifetime.TagsToMatch);
+        Assert.Contains(LifetimeScopeTag, lifetime.TagsToMatch);
     }
 
     [Fact]
@@ -164,15 +164,15 @@ public sealed class AutofacActorExtensionsTests
     public void RegisterActorCanBeCalledWithLifetimeScopeTag()
     {
         var builder = new ContainerBuilder();
-        const string lifetimeScopeTag = "Tag";
-        builder.RegisterActor<Actor1>(lifetimeScopeTag: lifetimeScopeTag);
+        const string LifetimeScopeTag = "Tag";
+        builder.RegisterActor<Actor1>(lifetimeScopeTag: LifetimeScopeTag);
         var factoryMock = Substitute.For<IActorFactoryRegistration>();
         builder.RegisterInstance(factoryMock);
 
         var container = builder.Build();
 
         container.AssertRegistered<Actor1>();
-        factoryMock.Received(1).RegisterActorFactory<Actor1>(container, typeof(ActorService), null, null, null, lifetimeScopeTag);
+        factoryMock.Received(1).RegisterActorFactory<Actor1>(container, typeof(ActorService), null, null, null, LifetimeScopeTag);
     }
 
     [Fact]

--- a/test/Autofac.Integration.ServiceFabric.Test/AutofacServiceExtensionsTests.cs
+++ b/test/Autofac.Integration.ServiceFabric.Test/AutofacServiceExtensionsTests.cs
@@ -47,8 +47,8 @@ public sealed class AutofacServiceExtensionsTests
         var container = builder.Build();
 
         var registration = container.RegistrationFor<StatefulService1>();
-        const string metadataKey = "Autofac.Extras.DynamicProxy.RegistrationExtensions.InterceptorsPropertyName";
-        var interceptorServices = (IEnumerable<Service>)registration.Metadata[metadataKey];
+        const string MetadataKey = "Autofac.Extras.DynamicProxy.RegistrationExtensions.InterceptorsPropertyName";
+        var interceptorServices = (IEnumerable<Service>)registration.Metadata[MetadataKey];
         Assert.Contains(new TypedService(typeof(ServiceInterceptor)), interceptorServices);
     }
 
@@ -63,8 +63,8 @@ public sealed class AutofacServiceExtensionsTests
         var container = builder.Build();
 
         var registration = container.RegistrationFor<StatelessService1>();
-        const string metadataKey = "Autofac.Extras.DynamicProxy.RegistrationExtensions.InterceptorsPropertyName";
-        var interceptorServices = (IEnumerable<Service>)registration.Metadata[metadataKey];
+        const string MetadataKey = "Autofac.Extras.DynamicProxy.RegistrationExtensions.InterceptorsPropertyName";
+        var interceptorServices = (IEnumerable<Service>)registration.Metadata[MetadataKey];
         Assert.Contains(new TypedService(typeof(ServiceInterceptor)), interceptorServices);
     }
 
@@ -106,8 +106,8 @@ public sealed class AutofacServiceExtensionsTests
     public void RegisterStatefulServiceWithTagRegistersInstancePerMatchingLifetimeScope()
     {
         var builder = new ContainerBuilder();
-        const string lifetimeScopeTag = "Tag";
-        builder.RegisterStatefulService<StatefulService1>("ServiceType", lifetimeScopeTag);
+        const string LifetimeScopeTag = "Tag";
+        builder.RegisterStatefulService<StatefulService1>("ServiceType", LifetimeScopeTag);
         builder.RegisterInstance(Substitute.For<IStatefulServiceFactoryRegistration>());
 
         var container = builder.Build();
@@ -117,15 +117,15 @@ public sealed class AutofacServiceExtensionsTests
         container.AssertOwnership<StatefulService1>(InstanceOwnership.OwnedByLifetimeScope);
 
         var lifetime = (MatchingScopeLifetime)container.RegistrationFor<StatefulService1>().Lifetime;
-        Assert.Contains(lifetimeScopeTag, lifetime.TagsToMatch);
+        Assert.Contains(LifetimeScopeTag, lifetime.TagsToMatch);
     }
 
     [Fact]
     public void RegisterStatelessServiceWithTagRegistersInstancePerMatchingLifetimeScope()
     {
         var builder = new ContainerBuilder();
-        const string lifetimeScopeTag = "Tag";
-        builder.RegisterStatelessService<StatelessService1>("ServiceType", lifetimeScopeTag);
+        const string LifetimeScopeTag = "Tag";
+        builder.RegisterStatelessService<StatelessService1>("ServiceType", LifetimeScopeTag);
         builder.RegisterInstance(Substitute.For<IStatelessServiceFactoryRegistration>());
 
         var container = builder.Build();
@@ -135,7 +135,7 @@ public sealed class AutofacServiceExtensionsTests
         container.AssertOwnership<StatelessService1>(InstanceOwnership.OwnedByLifetimeScope);
 
         var lifetime = (MatchingScopeLifetime)container.RegistrationFor<StatelessService1>().Lifetime;
-        Assert.Contains(lifetimeScopeTag, lifetime.TagsToMatch);
+        Assert.Contains(LifetimeScopeTag, lifetime.TagsToMatch);
     }
 
     [Fact]
@@ -168,30 +168,30 @@ public sealed class AutofacServiceExtensionsTests
     public void RegisterStatefulServiceCanBeCalledWithLifetimeScopeTag()
     {
         var builder = new ContainerBuilder();
-        const string lifetimeScopeTag = "CustomTag";
-        builder.RegisterStatefulService<StatefulService1>("ServiceType", lifetimeScopeTag);
+        const string LifetimeScopeTag = "CustomTag";
+        builder.RegisterStatefulService<StatefulService1>("ServiceType", LifetimeScopeTag);
         var factoryMock = Substitute.For<IStatefulServiceFactoryRegistration>();
         builder.RegisterInstance(factoryMock);
 
         var container = builder.Build();
 
         container.AssertRegistered<StatefulService1>();
-        factoryMock.Received(1).RegisterStatefulServiceFactory<StatefulService1>(container, "ServiceType", lifetimeScopeTag);
+        factoryMock.Received(1).RegisterStatefulServiceFactory<StatefulService1>(container, "ServiceType", LifetimeScopeTag);
     }
 
     [Fact]
     public void RegisterStatelessServiceCanBeCalledWithLifetimeScopeTag()
     {
         var builder = new ContainerBuilder();
-        const string lifetimeScopeTag = "CustomTag";
-        builder.RegisterStatelessService<StatelessService1>("ServiceType", lifetimeScopeTag);
+        const string LifetimeScopeTag = "CustomTag";
+        builder.RegisterStatelessService<StatelessService1>("ServiceType", LifetimeScopeTag);
         var factoryMock = Substitute.For<IStatelessServiceFactoryRegistration>();
         builder.RegisterInstance(factoryMock);
 
         var container = builder.Build();
 
         container.AssertRegistered<StatelessService1>();
-        factoryMock.Received(1).RegisterStatelessServiceFactory<StatelessService1>(container, "ServiceType", lifetimeScopeTag);
+        factoryMock.Received(1).RegisterStatelessServiceFactory<StatelessService1>(container, "ServiceType", LifetimeScopeTag);
     }
 
     [Fact]

--- a/test/Test.Scenario.InternalsVisible/InternalsVisibleActor.cs
+++ b/test/Test.Scenario.InternalsVisible/InternalsVisibleActor.cs
@@ -1,13 +1,12 @@
 ﻿using Microsoft.ServiceFabric.Actors;
 using Microsoft.ServiceFabric.Actors.Runtime;
 
-namespace Test.Scenario.InternalsVisible
+namespace Test.Scenario.InternalsVisible;
+
+// ReSharper disable once UnusedMember.Global
+internal class InternalsVisibleActor : Actor
 {
-    // ReSharper disable once UnusedMember.Global
-    internal class InternalsVisibleActor : Actor
+    public InternalsVisibleActor(ActorService actorService, ActorId actorId) : base(actorService, actorId)
     {
-        public InternalsVisibleActor(ActorService actorService, ActorId actorId) : base(actorService, actorId)
-        {
-        }
     }
 }

--- a/test/Test.Scenario.InternalsVisible/InternalsVisibleStatefulService.cs
+++ b/test/Test.Scenario.InternalsVisible/InternalsVisibleStatefulService.cs
@@ -2,14 +2,13 @@
 using Microsoft.ServiceFabric.Data;
 using Microsoft.ServiceFabric.Services.Runtime;
 
-namespace Test.Scenario.InternalsVisible
+namespace Test.Scenario.InternalsVisible;
+
+// ReSharper disable once UnusedMember.Global
+internal class InternalsVisibleStatefulService : StatefulServiceBase
 {
-    // ReSharper disable once UnusedMember.Global
-    internal class InternalsVisibleStatefulService : StatefulServiceBase
+    public InternalsVisibleStatefulService(StatefulServiceContext serviceContext, IStateProviderReplica2 stateProviderReplica)
+        : base(serviceContext, stateProviderReplica)
     {
-        public InternalsVisibleStatefulService(StatefulServiceContext serviceContext, IStateProviderReplica2 stateProviderReplica)
-            : base(serviceContext, stateProviderReplica)
-        {
-        }
     }
 }

--- a/test/Test.Scenario.InternalsVisible/InternalsVisibleStatelessService.cs
+++ b/test/Test.Scenario.InternalsVisible/InternalsVisibleStatelessService.cs
@@ -1,13 +1,12 @@
 ﻿using System.Fabric;
 using Microsoft.ServiceFabric.Services.Runtime;
 
-namespace Test.Scenario.InternalsVisible
+namespace Test.Scenario.InternalsVisible;
+
+// ReSharper disable once UnusedMember.Global
+internal class InternalsVisibleStatelessService : StatelessService
 {
-    // ReSharper disable once UnusedMember.Global
-    internal class InternalsVisibleStatelessService : StatelessService
+    public InternalsVisibleStatelessService(StatelessServiceContext serviceContext) : base(serviceContext)
     {
-        public InternalsVisibleStatelessService(StatelessServiceContext serviceContext) : base(serviceContext)
-        {
-        }
     }
 }


### PR DESCRIPTION
## Summary

- Standardize `.pre-commit-config.yaml`, `.editorconfig`, `build/stylecop.json`, `build/Source.ruleset`, `build/Test.ruleset` to match Autofac core
- Update `default.proj` Package target to pack individual projects
- Apply `dotnet format` code formatting
- Fix SA1201 member ordering (constructors before properties)
- Fix SA1404 SuppressMessage justifications

## Test plan

- [ ] CI build passes
- [ ] All tests pass
- [ ] `pre-commit run --all-files` passes