### PR TITLE
Add SonarAnalyzer.CSharp and tighten Roslyn analyzer rules

### DIFF
--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -4,6 +4,8 @@
   <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
     <!-- Implement standard exception constructors - not all of the exception constructors are desired. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Implement IDisposable correctly (must be explicitly enabled). -->
+    <Rule Id="CA1063" Action="Warning" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
     <!-- Avoid excessive complexity (must be explicitly enabled). -->
@@ -44,6 +46,8 @@
     <!-- Loops should use LINQ - DI container hot paths intentionally avoid LINQ allocations. -->
     <Rule Id="S3267" Action="None" />
     <Rule Id="S3776" Action="Warning" />
+    <!-- IDisposable pattern - Autofac uses non-standard dispose patterns for container lifecycle. -->
+    <Rule Id="S3881" Action="None" />
     <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
     <Rule Id="S4456" Action="None" />
     <Rule Id="S6418" Action="Warning" />

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -32,6 +32,8 @@
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
     <!-- "Sonar Way" rules to match SonarQube scans. -->
     <Rule Id="S107" Action="Warning" />
+    <!-- Do not use obsolete members - Autofac maintains deprecated APIs for backward compat. -->
+    <Rule Id="S1133" Action="None" />
     <Rule Id="S1192" Action="Warning" />
     <Rule Id="S1313" Action="Warning" />
     <Rule Id="S2259" Action="Warning" />

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac source assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
-  <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
-    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
+    <!-- Implement standard exception constructors - not all of the exception constructors are desired. -->
     <Rule Id="CA1032" Action="None" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
@@ -12,22 +12,40 @@
     <Rule Id="CA1505" Action="Warning" />
     <!-- Avoid excessive class coupling (must be explicitly enabled). -->
     <Rule Id="CA1506" Action="Warning" />
-    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <!-- Use ArgumentNullException.ThrowIfNull - not available in netstandard. -->
     <Rule Id="CA1510" Action="None" />
-    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - this isn't available until we stop targeting anything below net8.0. -->
+    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - not available below net8.0. -->
     <Rule Id="CA1512" Action="None" />
-    <!-- Use ObjectDisposedException.ThrowIf - this isn't available until we stop targeting anything below net8.0. -->
+    <!-- Use ObjectDisposedException.ThrowIf - not available below net8.0. -->
     <Rule Id="CA1513" Action="None" />
-    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
+    <!-- Change names to avoid reserved word overlaps - would break public API. -->
     <Rule Id="CA1716" Action="None" />
-    <!-- Cache a CompositeFormat object for use in String.Format - this isn't available until we stop targeting netstandard, and we only String.Format when throwing exceptions so the work/complexity isn't justified to increase perf just for those situations. -->
+    <!-- Cache a CompositeFormat - not available in netstandard. -->
     <Rule Id="CA1863" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core. -->
+    <!-- Implement serialization constructors - false positive in .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive in .NET Core. -->
     <Rule Id="CA2237" Action="None" />
-    <!-- Prefer generic overloads to using Type parameters - many aren't available in earlier frameworks; and we do a lot of reflection work in Autofac. -->
+    <!-- Prefer generic overloads - conflicts with reflection work in Autofac. -->
     <Rule Id="CA2263" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
+    <!-- "Sonar Way" rules to match SonarQube scans. -->
+    <Rule Id="S107" Action="Warning" />
+    <Rule Id="S1192" Action="Warning" />
+    <Rule Id="S1313" Action="Warning" />
+    <Rule Id="S2259" Action="Warning" />
+    <Rule Id="S2583" Action="Warning" />
+    <Rule Id="S2589" Action="Warning" />
+    <!-- Verify reflection accessibility bypass - DI containers do extensive reflection by design. -->
+    <Rule Id="S3011" Action="None" />
+    <!-- Loops should use LINQ - DI container hot paths intentionally avoid LINQ allocations. -->
+    <Rule Id="S3267" Action="None" />
+    <Rule Id="S3776" Action="Warning" />
+    <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
+    <Rule Id="S4456" Action="None" />
+    <Rule Id="S6418" Action="Warning" />
+    <Rule Id="S6444" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- Prefix local calls with this. -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -55,6 +55,8 @@
     <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
     <Rule Id="S1215" Action="None" />
     <!-- Remove unused private members - reflection tests need non-public members. -->
+    <!-- Do not use obsolete members - tests exercise deprecated APIs to verify backward compat. -->
+    <Rule Id="S1133" Action="None" />
     <Rule Id="S1144" Action="None" />
     <!-- Empty method bodies - test stubs often have no-op implementations. -->
     <Rule Id="S1186" Action="None" />

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -42,6 +42,8 @@
     <Rule Id="CA2234" Action="None" />
     <!-- Mark ISerializable types with SerializableAttribute - false positive in .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Nested types should not be visible - test scenario classes use nested types extensively. -->
+    <Rule Id="CA1034" Action="None" />
     <!-- Prefer generic overloads - reflection work in Autofac needs to be tested. -->
     <Rule Id="CA2263" Action="None" />
   </Rules>

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -23,6 +23,10 @@
     <!-- Remove underscores from member name - test naming conventions use underscore. -->
     <Rule Id="CA1707" Action="None" />
     <!-- Internal class that appears to never be instantiated - false positives from DI. -->
+    <!-- Identifiers should not have incorrect suffix - test classes use Impl, Handler, etc. -->
+    <Rule Id="CA1711" Action="None" />
+    <!-- Property names should not match get methods - aggregate service tests intentionally test both. -->
+    <Rule Id="CA1721" Action="None" />
     <Rule Id="CA1812" Action="None" />
     <!-- Change Dispose() to call GC.SuppressFinalize - unimportant in tests. -->
     <Rule Id="CA1816" Action="None" />
@@ -55,6 +59,8 @@
     <!-- Don't use hardcoded paths or URIs - needed in several test cases. -->
     <Rule Id="S1075" Action="None" />
     <!-- Utility class should not be instantiated - test fixture classes with nested tests can't be static. -->
+    <!-- Sections of code should not be commented out - test files may retain commented examples. -->
+    <Rule Id="S125" Action="None" />
     <Rule Id="S1118" Action="None" />
     <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
     <Rule Id="S1215" Action="None" />

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -39,6 +39,8 @@
     <!-- Call ConfigureAwait - shouldn't in test libraries; XUnit has opposing analyzer. -->
     <Rule Id="CA2007" Action="None" />
     <!-- Implement serialization constructors - false positive in .NET Core. -->
+    <!-- Do not raise reserved exception types - tests use generic exceptions for simulation. -->
+    <Rule Id="CA2201" Action="None" />
     <Rule Id="CA2229" Action="None" />
     <!-- Use Uri instead of string parameters - strings are easier for testing. -->
     <Rule Id="CA2234" Action="None" />

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -6,6 +6,8 @@
     <Rule Id="CA1031" Action="None" />
     <!-- Avoid empty interfaces - happens a lot in unit tests for service resolution. -->
     <Rule Id="CA1040" Action="None" />
+    <!-- Implement IDisposable correctly (must be explicitly enabled). -->
+    <Rule Id="CA1063" Action="Warning" />
     <!-- Do not pass literals as localized parameters - tests don't need to localize. -->
     <Rule Id="CA1303" Action="None" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
@@ -54,9 +56,9 @@
     <Rule Id="S1118" Action="None" />
     <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
     <Rule Id="S1215" Action="None" />
-    <!-- Remove unused private members - reflection tests need non-public members. -->
     <!-- Do not use obsolete members - tests exercise deprecated APIs to verify backward compat. -->
     <Rule Id="S1133" Action="None" />
+    <!-- Remove unused private members - reflection tests need non-public members. -->
     <Rule Id="S1144" Action="None" />
     <!-- Empty method bodies - test stubs often have no-op implementations. -->
     <Rule Id="S1186" Action="None" />
@@ -80,6 +82,8 @@
     <Rule Id="S2335" Action="None" />
     <!-- Cognitive complexity (must be explicitly enabled). -->
     <Rule Id="S3776" Action="Warning" />
+    <!-- IDisposable pattern - test dispose implementations are intentionally simplified. -->
+    <Rule Id="S3881" Action="None" />
     <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
     <Rule Id="S4456" Action="None" />
     <!-- Don't use Thread.Sleep - required for concurrency and timing tests. -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -1,16 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac test assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
-  <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
-    <!-- Avoid excessive parameters on generic types (must be explicitly enabled). -->
-    <Rule Id="CA1005" Action="Warning" />
-    <!-- Don't catch general exceptions - test scenarios sometimes require general exception handling. -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
+    <!-- Don't catch general exceptions - test scenarios sometimes require it. -->
     <Rule Id="CA1031" Action="None" />
-    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
-    <Rule Id="CA1032" Action="None" />
-    <!-- Avoid empty interfaces - in unit tests for service resolution, this happens a lot. -->
+    <!-- Avoid empty interfaces - happens a lot in unit tests for service resolution. -->
     <Rule Id="CA1040" Action="None" />
-    <!-- Do not pass literals as localized parameters  - tests don't need to localize. -->
+    <!-- Do not pass literals as localized parameters - tests don't need to localize. -->
     <Rule Id="CA1303" Action="None" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
@@ -20,36 +16,78 @@
     <Rule Id="CA1505" Action="Warning" />
     <!-- Avoid excessive class coupling (must be explicitly enabled). -->
     <Rule Id="CA1506" Action="Warning" />
-    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
-    <Rule Id="CA1510" Action="None" />
-    <!-- Make API types internal - causes problems with tests and test assemblies. -->
+    <!-- Make API types internal - causes problems with tests. -->
     <Rule Id="CA1515" Action="None" />
-    <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
+    <!-- Remove underscores from member name - test naming conventions use underscore. -->
     <Rule Id="CA1707" Action="None" />
-    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
-    <Rule Id="CA1716" Action="None" />
-    <!-- Internal class that appears to never be instantiated - lots of false positives here because they're test stubs created by Autofac registrations. -->
+    <!-- Internal class that appears to never be instantiated - false positives from DI. -->
     <Rule Id="CA1812" Action="None" />
-    <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
+    <!-- Change Dispose() to call GC.SuppressFinalize - unimportant in tests. -->
     <Rule Id="CA1816" Action="None" />
-    <!-- Mark members static - test methods may not access member data but also can't be static. -->
+    <!-- Mark members static - test methods may not access member data. -->
     <Rule Id="CA1822" Action="None" />
-    <!-- Seal internal types for performance - in tests we don't really care and it gets painful to enforce. -->
+    <!-- Use the LoggerMessage delegates - noise in tests, performance irrelevant. -->
+    <Rule Id="CA1848" Action="None" />
+    <!-- Seal internal types - unimportant in tests. -->
     <Rule Id="CA1852" Action="None" />
-    <!-- Prefer static readonly fields over constant array arguments - constant array arguments happen a lot in unit tests for assertions and test setup. -->
+    <!-- Prefer static readonly fields over constant arrays - happens in test setup. -->
     <Rule Id="CA1861" Action="None" />
-    <!-- Cache a CompositeFormat object for use in String.Format - this makes unit tests harder to read, and performance isn't an issue. -->
+    <!-- Cache a CompositeFormat - makes tests harder to read. -->
     <Rule Id="CA1863" Action="None" />
-    <!-- Call ConfigureAwait on tasks - you shouldn't do this in unit test libraries; XUnit has an opposite analyzer. -->
+    <!-- Call ConfigureAwait - shouldn't in test libraries; XUnit has opposing analyzer. -->
     <Rule Id="CA2007" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core. -->
+    <!-- Implement serialization constructors - false positive in .NET Core. -->
     <Rule Id="CA2229" Action="None" />
     <!-- Use Uri instead of string parameters - strings are easier for testing. -->
     <Rule Id="CA2234" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive in .NET Core. -->
     <Rule Id="CA2237" Action="None" />
-    <!-- Prefer generic overloads to using Type parameters - we do a lot of reflection work in Autofac that needs to be tested. -->
+    <!-- Prefer generic overloads - reflection work in Autofac needs to be tested. -->
     <Rule Id="CA2263" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
+    <!-- Don't use hardcoded paths or URIs - needed in several test cases. -->
+    <Rule Id="S1075" Action="None" />
+    <!-- Utility class should not be instantiated - test fixture classes with nested tests can't be static. -->
+    <Rule Id="S1118" Action="None" />
+    <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
+    <Rule Id="S1215" Action="None" />
+    <!-- Remove unused private members - reflection tests need non-public members. -->
+    <Rule Id="S1144" Action="None" />
+    <!-- Empty method bodies - test stubs often have no-op implementations. -->
+    <Rule Id="S1186" Action="None" />
+    <!-- Remove unused method parameters - reflection tests declare parameters not used in the body. -->
+    <Rule Id="S1172" Action="None" />
+    <!-- Remove empty class - test stubs for DI resolution don't need implementation. -->
+    <Rule Id="S2094" Action="None" />
+    <!-- Make member static - test fixture members may not access instance data. -->
+    <Rule Id="S2325" Action="None" />
+    <!-- Remove unused type parameters - used in reflection testing. -->
+    <Rule Id="S2326" Action="None" />
+    <!-- Write-only properties - reflection tests verify property setter behavior. -->
+    <Rule Id="S2376" Action="None" />
+    <!-- Classes with only private constructors - reflection tests verify inaccessible constructors. -->
+    <Rule Id="S3453" Action="None" />
+    <!-- Remove unassigned auto-property - reflection tests verify non-public property behavior. -->
+    <Rule Id="S3459" Action="None" />
+    <!-- Complete the TODO - acceptable in tests for backlog items. -->
+    <Rule Id="S1135" Action="None" />
+    <!-- Make instance property static - false positives in data/document types. -->
+    <Rule Id="S2335" Action="None" />
+    <!-- Cognitive complexity (must be explicitly enabled). -->
+    <Rule Id="S3776" Action="Warning" />
+    <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
+    <Rule Id="S4456" Action="None" />
+    <!-- Don't use Thread.Sleep - required for concurrency and timing tests. -->
+    <Rule Id="S2925" Action="None" />
+    <!-- NSubstitute mock verification is complete without property access. -->
+    <Rule Id="S2970" Action="None" />
+    <!-- Fields only assigned in constructor - needed to prevent optimization in reflection tests. -->
+    <Rule Id="S4487" Action="None" />
+    <!-- Set route attributes at top of controller - false positive. -->
+    <Rule Id="S6934" Action="None" />
+    <!-- Use async dispose - sync dispose tests are intentional. -->
+    <Rule Id="S6966" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- Prefix local calls with this. -->
@@ -58,11 +96,11 @@
     <Rule Id="SA1121" Action="None" />
     <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Enforce order of class members by member type - sometimes putting test classes/data by the test helps. -->
+    <!-- Enforce order of class members by member type. -->
     <Rule Id="SA1201" Action="None" />
-    <!-- Enforce order of class members by member visibility - sometimes putting test classes/data by the test helps. -->
+    <!-- Enforce order of class members by visibility. -->
     <Rule Id="SA1202" Action="None" />
-    <!-- Enforce order of static vs. non-static members - sometimes putting test classes/data by the test helps. -->
+    <!-- Enforce order of static vs. non-static members. -->
     <Rule Id="SA1204" Action="None" />
     <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
@@ -82,6 +120,13 @@
     <Rule Id="SA1618" Action="None" />
     <!-- Don't copy/paste documentation. -->
     <Rule Id="SA1625" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="xUnit" RuleNamespace="xUnit">
+    <!-- Use Assert.Single when there's only one collection entry. -->
+    <Rule Id="xUnit2023" Action="Warning" />
+  </Rules>
+  <!-- IDE rules for test assemblies. -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
     <!-- Private member is unused - tests for reflection require members that may not get used. -->
     <Rule Id="IDE0051" Action="None" />
     <!-- Private member assigned value never read - tests for reflection require values that may not get used. -->

--- a/src/Autofac.Integration.ServiceFabric/ActorFactoryRegistration.cs
+++ b/src/Autofac.Integration.ServiceFabric/ActorFactoryRegistration.cs
@@ -46,7 +46,7 @@ internal sealed class ActorFactoryRegistration : IActorFactoryRegistration
 
     /// <inheritdoc />
     public void RegisterActorFactory<TActor>(
-        ILifetimeScope container,
+        ILifetimeScope lifetimeScope,
         Type actorServiceType,
         Func<ActorBase, IActorStateProvider, IActorStateManager>? stateManagerFactory = null,
         IActorStateProvider? stateProvider = null,
@@ -59,7 +59,7 @@ internal sealed class ActorFactoryRegistration : IActorFactoryRegistration
             ActorBase ActorFactory(ActorService actorService, ActorId actorId)
             {
                 var tag = lifetimeScopeTag ?? Constants.DefaultLifetimeScopeTag;
-                var lifetimeScope = container.BeginLifetimeScope(tag, builder =>
+                var lifetimeScope = lifetimeScope.BeginLifetimeScope(tag, builder =>
                 {
                     builder.RegisterInstance(context)
                         .As<StatefulServiceContext>()
@@ -87,7 +87,7 @@ internal sealed class ActorFactoryRegistration : IActorFactoryRegistration
                 }
             }
 
-            return (ActorService)container.Resolve(
+            return (ActorService)lifetimeScope.Resolve(
                 actorServiceType,
                 new TypedParameter(typeof(StatefulServiceContext), context),
                 new TypedParameter(typeof(ActorTypeInformation), actorTypeInfo),

--- a/src/Autofac.Integration.ServiceFabric/ActorFactoryRegistration.cs
+++ b/src/Autofac.Integration.ServiceFabric/ActorFactoryRegistration.cs
@@ -59,7 +59,7 @@ internal sealed class ActorFactoryRegistration : IActorFactoryRegistration
             ActorBase ActorFactory(ActorService actorService, ActorId actorId)
             {
                 var tag = lifetimeScopeTag ?? Constants.DefaultLifetimeScopeTag;
-                var lifetimeScope = lifetimeScope.BeginLifetimeScope(tag, builder =>
+                var serviceScope = lifetimeScope.BeginLifetimeScope(tag, builder =>
                 {
                     builder.RegisterInstance(context)
                         .As<StatefulServiceContext>()
@@ -74,13 +74,13 @@ internal sealed class ActorFactoryRegistration : IActorFactoryRegistration
 
                 try
                 {
-                    var actor = lifetimeScope.Resolve<TActor>();
+                    var actor = serviceScope.Resolve<TActor>();
                     return actor;
                 }
                 catch (Exception ex)
                 {
                     // Proactively dispose lifetime scope as interceptor will not be called.
-                    lifetimeScope.Dispose();
+                    serviceScope.Dispose();
 
                     ConstructorExceptionCallback(ex);
                     throw;

--- a/src/Autofac.Integration.ServiceFabric/Autofac.Integration.ServiceFabric.csproj
+++ b/src/Autofac.Integration.ServiceFabric/Autofac.Integration.ServiceFabric.csproj
@@ -21,6 +21,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>../../build/Source.ruleset</CodeAnalysisRuleSet>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <ImplicitUsings>enable</ImplicitUsings>
     <PlatformTarget>x64</PlatformTarget>
     <!-- Packaging -->
@@ -67,6 +68,10 @@
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/src/Autofac.Integration.ServiceFabric/StatefulServiceFactoryRegistration.cs
+++ b/src/Autofac.Integration.ServiceFabric/StatefulServiceFactoryRegistration.cs
@@ -51,7 +51,7 @@ internal sealed class StatefulServiceFactoryRegistration : IStatefulServiceFacto
         ServiceRuntime.RegisterServiceAsync(serviceTypeName, context =>
         {
             var tag = lifetimeScopeTag ?? Constants.DefaultLifetimeScopeTag;
-            var lifetimeScope = lifetimeScope.BeginLifetimeScope(tag, builder =>
+            var serviceScope = lifetimeScope.BeginLifetimeScope(tag, builder =>
             {
                 builder.RegisterInstance(context)
                     .As<StatefulServiceContext>()
@@ -62,13 +62,13 @@ internal sealed class StatefulServiceFactoryRegistration : IStatefulServiceFacto
 
             try
             {
-                var service = lifetimeScope.Resolve<TService>();
+                var service = serviceScope.Resolve<TService>();
                 return service;
             }
             catch (Exception ex)
             {
                 // Proactively dispose lifetime scope as interceptor will not be called.
-                lifetimeScope.Dispose();
+                serviceScope.Dispose();
 
                 ConstructorExceptionCallback(ex);
                 throw;

--- a/src/Autofac.Integration.ServiceFabric/StatefulServiceFactoryRegistration.cs
+++ b/src/Autofac.Integration.ServiceFabric/StatefulServiceFactoryRegistration.cs
@@ -45,13 +45,13 @@ internal sealed class StatefulServiceFactoryRegistration : IStatefulServiceFacto
 
     /// <inheritdoc />
     public void RegisterStatefulServiceFactory<TService>(
-        ILifetimeScope container, string serviceTypeName, object? lifetimeScopeTag = null)
+        ILifetimeScope lifetimeScope, string serviceTypeName, object? lifetimeScopeTag = null)
         where TService : StatefulServiceBase
     {
         ServiceRuntime.RegisterServiceAsync(serviceTypeName, context =>
         {
             var tag = lifetimeScopeTag ?? Constants.DefaultLifetimeScopeTag;
-            var lifetimeScope = container.BeginLifetimeScope(tag, builder =>
+            var lifetimeScope = lifetimeScope.BeginLifetimeScope(tag, builder =>
             {
                 builder.RegisterInstance(context)
                     .As<StatefulServiceContext>()

--- a/src/Autofac.Integration.ServiceFabric/StatelessServiceFactoryRegistration.cs
+++ b/src/Autofac.Integration.ServiceFabric/StatelessServiceFactoryRegistration.cs
@@ -45,13 +45,13 @@ internal sealed class StatelessServiceFactoryRegistration : IStatelessServiceFac
 
     /// <inheritdoc />
     public void RegisterStatelessServiceFactory<TService>(
-        ILifetimeScope container, string serviceTypeName, object? lifetimeScopeTag = null)
+        ILifetimeScope lifetimeScope, string serviceTypeName, object? lifetimeScopeTag = null)
         where TService : StatelessService
     {
         ServiceRuntime.RegisterServiceAsync(serviceTypeName, context =>
         {
             var tag = lifetimeScopeTag ?? Constants.DefaultLifetimeScopeTag;
-            var lifetimeScope = container.BeginLifetimeScope(tag, builder =>
+            var lifetimeScope = lifetimeScope.BeginLifetimeScope(tag, builder =>
             {
                 builder.RegisterInstance(context)
                     .As<StatelessServiceContext>()

--- a/src/Autofac.Integration.ServiceFabric/StatelessServiceFactoryRegistration.cs
+++ b/src/Autofac.Integration.ServiceFabric/StatelessServiceFactoryRegistration.cs
@@ -51,7 +51,7 @@ internal sealed class StatelessServiceFactoryRegistration : IStatelessServiceFac
         ServiceRuntime.RegisterServiceAsync(serviceTypeName, context =>
         {
             var tag = lifetimeScopeTag ?? Constants.DefaultLifetimeScopeTag;
-            var lifetimeScope = lifetimeScope.BeginLifetimeScope(tag, builder =>
+            var serviceScope = lifetimeScope.BeginLifetimeScope(tag, builder =>
             {
                 builder.RegisterInstance(context)
                     .As<StatelessServiceContext>()
@@ -62,13 +62,13 @@ internal sealed class StatelessServiceFactoryRegistration : IStatelessServiceFac
 
             try
             {
-                var service = lifetimeScope.Resolve<TService>();
+                var service = serviceScope.Resolve<TService>();
                 return service;
             }
             catch (Exception ex)
             {
                 // Proactively dispose lifetime scope as interceptor will not be called.
-                lifetimeScope.Dispose();
+                serviceScope.Dispose();
 
                 ConstructorExceptionCallback(ex);
                 throw;

--- a/test/Autofac.Integration.ServiceFabric.Test/Autofac.Integration.ServiceFabric.Test.csproj
+++ b/test/Autofac.Integration.ServiceFabric.Test/Autofac.Integration.ServiceFabric.Test.csproj
@@ -8,6 +8,8 @@
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -46,6 +48,10 @@
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/test/Test.Scenario.InternalsVisible/Test.Scenario.InternalsVisible.csproj
+++ b/test/Test.Scenario.InternalsVisible/Test.Scenario.InternalsVisible.csproj
@@ -6,6 +6,8 @@
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -16,6 +18,10 @@
     <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="8.0.0" />
     <PackageReference Include="Microsoft.ServiceFabric.Data" Version="8.0.0" />
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="8.0.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Adds SonarAnalyzer.CSharp (10.27.0.140913) to all projects
- Introduces unified `build/Source.ruleset` and `build/Test.ruleset` with consistent analyzer configuration
- Fixes all actionable analyzer warnings (code changes per-rule in individual commits)
- Disables rules that are false positives or inapplicable for this project's patterns

## Changes

- **New analyzer**: SonarAnalyzer.CSharp added via PackageReference with PrivateAssets=all
- **Rulesets**: Unified Source.ruleset and Test.ruleset covering Microsoft, Sonar, StyleCop, and xUnit analyzers
- **Code fixes**: Various warning fixes committed individually by rule ID for easy review
- **Zero warnings**: Build completes with no analyzer warnings

## Test plan

- [ ] CI build passes (zero errors, zero warnings)
- [ ] All existing tests pass
- [ ] No public API changes (verify with `dotnet format --verify-no-changes`)